### PR TITLE
Width and height: allow numbers and any strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ export default class Examples extends Component {
 |:------------|:---------|:---------|:--------------------------------------------|:-----------------------------|
 | visible     | required | Boolean  | to show or hide the dialog                  | false                        |
 | effect      | option   | String   | to set how to pop-up                        | fadeInUp, fadeInDown, etc... |
-| width       | option   | String   | to set modal width (px or %)                | 500, 500px, 80%              |
-| height      | option   | String   | to set modal height (px or %)               | 400, 400px, 50%              |
+| width       | option   | String   | to set modal width                          | 500, 500px, 80%, auto        |
+| height      | option   | String   | to set modal height                         | 400, 400px, 50%, auto        |
 | onClickAway | option   | Function | to set actions when the user click the mask | -                            |
 
 ## Effect

--- a/src/index.js
+++ b/src/index.js
@@ -30,36 +30,21 @@ export default class Modal extends Component {
     }
 
     setSize(effect) {
-        if (this.props && this.props.width) {
-            if (this.props.width.charAt(this.props.width.length-1) === '%') {
-                // Use Percentage
-                const width = this.props.width.slice(0, -1);
-                style[effect].panel.width = width + '%';
-
-            } else if (this.props.width.charAt(this.props.width.length-1) === 'x') {
-                // Use Pixels
-                const width = this.props.width.slice(0, -2);
-                style[effect].panel.width = width + 'px';
-
+        if (this.props.width) {
+            if (!isNaN(this.props.width)) {
+                // numeric values in Pixel
+                style[effect].panel.width = `${this.props.width}px`
             } else {
-                // Defaults
-                style[effect].panel.width = this.props.width + 'px';
+                style[effect].panel.width = this.props.width
             }
         }
-        if (this.props && this.props.height) {
-            if (this.props.height.charAt(this.props.height.length-1) === '%') {
-                // Use Percentage
-                const height = this.props.height.slice(0, -1);
-                style[effect].panel.height = height + 'vh';
-
-            } else if (this.props.height.charAt(this.props.height.length-1) === 'x') {
-                // Use Pixels
-                const height = this.props.height.slice(0, -2);
-                style[effect].panel.height = height + 'px';
-
-            } else {
-                // Defaults
-                style[effect].panel.height = this.props.height + 'px';
+        if (this.props.height) {
+            if (!isNaN(this.props.height)) {
+                // numeric values in Pixel
+                style[effect].panel.height = `${this.props.height}px`
+            }
+            else {
+                style[effect].panel.height = this.props.height
             }
         }
     }


### PR DESCRIPTION
Changed the width and height setting in order to accept any strings such as "auto". 
Numeric values get an added px so the historic behaviour does not change.