### PR TITLE
Let onClick return null instead of false to get rid of React16 warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ export default class Modal extends Component {
                     <div style={this.state.visible ? {...this.state.style.panel} : this.state.style.panelHidden}>
                         {this.props.children}
                     </div>
-                    <div style={this.state.visible ? this.state.style.mask : this.state.style.maskHidden} onClick={this.props.onClickAway ? this.props.onClickAway : false} />
+                    <div style={this.state.visible ? this.state.style.mask : this.state.style.maskHidden} onClick={this.props.onClickAway ? this.props.onClickAway : null} />
                 </div>
             </div>
         );


### PR DESCRIPTION
Warning before this pull request:

> Warning: Expected `onClick` listener to be a function, instead got `false`.
> 
> If you used to conditionally omit it with onClick={condition && value}, pass onClick={condition ? value : undefined} instead.
>     in div (created by Modal)
>     in div (created by Modal)
>     in div (created by Modal)

This is caused by 
`<div style={this.state.visible ? this.state.style.mask : this.state.style.maskHidden} onClick={this.props.onClickAway ? this.props.onClickAway : false}`

This PR replaces `false` by `null`